### PR TITLE
[HOTFIX] BottomSheet 컴포넌트 내 content 리사이징 이슈 및 기타 수정

### DIFF
--- a/src/components/BottomSheet/BottomSheet.styles.ts
+++ b/src/components/BottomSheet/BottomSheet.styles.ts
@@ -36,6 +36,8 @@ export const StyledBottomSheet = styled.div<
 >`
   width: 100%;
   max-height: 90%;
+  display: flex;
+  flex-direction: column;
   background-color: ${({ theme: { palette } }) => palette.common.white};
   border-radius: 16px 16px 0 0;
   box-shadow: ${({
@@ -71,14 +73,8 @@ export const SwipeZone = styled.div`
   touch-action: none;
 `;
 
-export const Content = styled.div<{ maxHeight: number; swipeZoneHeight: number }>`
-  ${({ maxHeight, swipeZoneHeight }): CSSObject => {
-    let calcMaxHeight = maxHeight ? `${maxHeight}px` : '100%';
-    if (swipeZoneHeight) calcMaxHeight = `calc(${calcMaxHeight} - ${swipeZoneHeight}px)`;
-    return {
-      maxHeight: calcMaxHeight
-    };
-  }};
+export const Content = styled.div`
+  flex: 1;
   overflow-x: hidden;
   overflow-y: auto;
 `;

--- a/src/components/BottomSheet/index.tsx
+++ b/src/components/BottomSheet/index.tsx
@@ -29,8 +29,6 @@ const BottomSheet = forwardRef<HTMLDivElement, PropsWithChildren<BottomSheetProp
     const [isMounted, setIsMounted] = useState<boolean>(false);
     const [sheetOpen, setSheetOpen] = useState<boolean>(false);
     const [swipeable, setSwipeable] = useState<boolean>(false);
-    const [sheetContentHeight, setSheetContentHeight] = useState<number>(0);
-    const [sheetSwipeZoneHeight, setSheetSwipeZoneHeight] = useState<number>(0);
 
     const sheetPortalRef = useRef<HTMLElement | null>(null);
     const sheetRef = useRef<HTMLDivElement | null>(null);
@@ -130,16 +128,6 @@ const BottomSheet = forwardRef<HTMLDivElement, PropsWithChildren<BottomSheetProp
       }
     }, [open, isMounted, transitionDuration]);
 
-    useEffect(() => {
-      if (sheetOpen && sheetRef.current) {
-        setSheetContentHeight(sheetRef.current?.clientHeight);
-      }
-
-      if (sheetOpen && sheetSwipeZoneRef.current) {
-        setSheetSwipeZoneHeight(sheetSwipeZoneRef.current?.clientHeight);
-      }
-    }, [sheetOpen]);
-
     if (isMounted && sheetPortalRef.current) {
       return createPortal(
         <Wrapper
@@ -170,13 +158,7 @@ const BottomSheet = forwardRef<HTMLDivElement, PropsWithChildren<BottomSheetProp
                 <Rectangle />
               </SwipeZone>
             )}
-            <Content
-              maxHeight={sheetContentHeight}
-              swipeZoneHeight={sheetSwipeZoneHeight}
-              {...props}
-            >
-              {children}
-            </Content>
+            <Content {...props}>{children}</Content>
           </StyledBottomSheet>
         </Wrapper>,
         sheetPortalRef.current

--- a/src/components/Button/CtaButton/index.tsx
+++ b/src/components/Button/CtaButton/index.tsx
@@ -29,7 +29,7 @@ const CtaButton = forwardRef<HTMLButtonElement, PropsWithChildren<CtaButtonProps
       variant = 'outlined',
       brandColor = 'black',
       size = 'medium',
-      weight = 'regular',
+      weight = 'medium',
       startIcon,
       endIcon,
       iconOnly = false,

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -28,7 +28,7 @@ const Button = forwardRef<HTMLButtonElement, PropsWithChildren<ButtonProps>>(fun
     variant = 'outlined',
     brandColor = 'grey',
     size = 'medium',
-    weight = 'regular',
+    weight = 'medium',
     startIcon,
     endIcon,
     iconOnly = false,

--- a/src/components/Chip/index.tsx
+++ b/src/components/Chip/index.tsx
@@ -29,7 +29,7 @@ const Chip = forwardRef<HTMLButtonElement, PropsWithChildren<ChipProps>>(functio
     variant = 'outlined',
     brandColor = 'grey',
     size = 'medium',
-    weight = 'regular',
+    weight = 'medium',
     isRound = true,
     startIcon,
     endIcon,


### PR DESCRIPTION
- `BottomSheet` 컴포넌트 내 content 리사이징 이슈
  - 모바일 웹 어드레스 바 영향으로 인한 여백 발생 문제 수정
  - ![image](https://user-images.githubusercontent.com/64636159/174740543-d018f8e8-08a7-4972-8116-96e6c1feac7a.png)
- `Button`, `Chip` 컴포넌트의 default weight 수정
  - 피그마에서 `Button`, `Chip` 컴포넌트 모두 공통으로 `medium` weight 이 지정되어 있음