### PR TITLE
[HOTFIX] 일부 컴포넌트 피그마와 상이한 style 및 기타 수정

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -49,7 +49,7 @@ export function Variants() {
           ghost
         </Button>
         <Button variant="outlinedGhost" brandColor="primary">
-          ghost
+          outlinedGhost
         </Button>
         <Button variant="contained" brandColor="primary">
           contained

--- a/src/components/Button/CtaButton/index.tsx
+++ b/src/components/Button/CtaButton/index.tsx
@@ -13,7 +13,7 @@ import { TypographyWeight } from '../../../types';
 
 export interface BaseCtaButtonProps
   extends GenericComponentProps<ButtonHTMLAttributes<HTMLButtonElement>> {
-  variant?: Variant;
+  variant?: Exclude<Variant, 'outlinedGhost'>;
   brandColor?: Extract<BrandColor, 'black' | 'primary'>;
   size?: Exclude<Size, 'xsmall' | 'small' | 'xlarge'>;
   weight?: keyof TypographyWeight;

--- a/src/components/Dialog/Dialog.styles.ts
+++ b/src/components/Dialog/Dialog.styles.ts
@@ -62,11 +62,15 @@ export const StyledDialog = styled.div<
     }
   }) => shadow.modal};
 
-  ${({ fullScreen }): CSSObject =>
+  ${({
+    fullScreen,
+    theme: {
+      box: { round }
+    }
+  }): CSSObject =>
     !fullScreen
       ? {
-          borderRadius: 8,
-          boxShadow: '0 0 16px rgba(0, 0, 0, 0.1)'
+          borderRadius: round['16']
         }
       : {
           width: '100%',

--- a/src/components/Tooltip/Tooltip.styles.ts
+++ b/src/components/Tooltip/Tooltip.styles.ts
@@ -17,7 +17,6 @@ export const StyledTooltip = styled.div<
     | 'spaceBetween'
     | 'transitionDuration'
     | 'triangleLeft'
-    | 'triangleCompact'
     | 'brandColor'
     | 'round'
     | 'disablePadding'
@@ -134,7 +133,7 @@ export const StyledTooltip = styled.div<
     content: '';
     position: absolute;
 
-    ${({ theme, brandColor, placement, triangleLeft, triangleCompact }): CSSObject => {
+    ${({ theme, brandColor, placement, triangleLeft, round }): CSSObject => {
       let brandColorCode = getBrandColorCodeByColorName(theme, brandColor);
 
       if (brandColor === 'black') {
@@ -145,14 +144,14 @@ export const StyledTooltip = styled.div<
         case 'left':
           return {
             top: '50%',
-            right: triangleCompact ? -10 : -15,
+            right: round === '16' ? -10 : -15,
             color: brandColorCode,
             transform: 'translateY(-50%) rotate(90deg)'
           };
         case 'right':
           return {
             top: '50%',
-            left: triangleCompact ? -10 : -15,
+            left: round === '16' ? -10 : -15,
             color: brandColorCode,
             transform: 'translateY(-50%) rotate(270deg)'
           };

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -19,7 +19,6 @@ export interface TooltipProps extends GenericComponentProps<HTMLAttributes<HTMLD
   spaceBetween?: number;
   transitionDuration?: number;
   triangleLeft?: number;
-  triangleCompact?: boolean;
   round?: Extract<BoxRoundKey, '8' | '16'>;
   disablePadding?: boolean;
   disableShadow?: boolean;
@@ -34,11 +33,10 @@ const Tooltip = forwardRef<HTMLDivElement, PropsWithChildren<TooltipProps>>(func
     spaceBetween = 20,
     transitionDuration = 225,
     triangleLeft,
-    triangleCompact = false,
     brandColor = 'black',
-    round = '8',
+    round = '16',
     disablePadding = false,
-    disableShadow = false,
+    disableShadow = true,
     customStyle,
     ...props
   },
@@ -92,7 +90,6 @@ const Tooltip = forwardRef<HTMLDivElement, PropsWithChildren<TooltipProps>>(func
         spaceBetween={spaceBetween}
         transitionDuration={transitionDuration}
         triangleLeft={triangleLeft}
-        triangleCompact={triangleCompact}
         brandColor={brandColor}
         round={round}
         disablePadding={disablePadding}
@@ -100,7 +97,7 @@ const Tooltip = forwardRef<HTMLDivElement, PropsWithChildren<TooltipProps>>(func
         css={customStyle}
       >
         {message}
-        {triangleCompact ? <TriangleCompact /> : <Triangle />}
+        {round === '16' ? <TriangleCompact /> : <Triangle />}
       </StyledTooltip>
     </Wrapper>
   );

--- a/src/theme/GlobalReset.tsx
+++ b/src/theme/GlobalReset.tsx
@@ -166,7 +166,7 @@ function GlobalReset() {
           display: 'none'
         },
         '*': {
-          '-webkit-tap-highlight-color': 'transparent'
+          WebkitTapHighlightColor: 'transparent'
         },
         '*,::before,::after': {
           '--tw-border-opacity': 1,

--- a/src/theme/light.ts
+++ b/src/theme/light.ts
@@ -163,6 +163,7 @@ export const light: MrCamelTheme = {
     dialog: 20,
     sheet: 20,
     alert: 20,
-    toast: 30
+    toast: 30,
+    tooltip: 40
   }
 };

--- a/src/types/theme.ts
+++ b/src/types/theme.ts
@@ -42,7 +42,7 @@ export interface MrCamelTheme {
   };
   breakpoints: Record<'xs' | 'sm' | 'md' | 'lg' | 'xl', number>;
   zIndex: Record<
-    'button' | 'header' | 'bottomNav' | 'dialog' | 'sheet' | 'alert' | 'toast',
+    'button' | 'header' | 'bottomNav' | 'dialog' | 'sheet' | 'alert' | 'toast' | 'tooltip',
     number
   >;
 }


### PR DESCRIPTION
- `Dialog` 컴포넌트 round 수정
- `GlobalReset` 컴포넌트 내 탭 하이라이트 속성명 수정
  - 지난번 수정에서 지원되지 않는 잘못된 속성명을 기재 함
- `CtaButton` 컴포넌트 지원되지 않는 Variant 타입 제외 처리
- `Tooltip` 컴포넌트 triangleCompact props 제거 및 `round`, `shadow` default 값 수정
  - `triangleCompact` props 는 지난번 수정에서 이전의 `Tooltip` 컴포넌트 관련 히스토리를 고려하지 않고 구현한 것이 비효율적인 방식으로 판단되어 제거
  - default `round` 와 `shadow` 는 실제 프로덕트 내에서의 사용 빈도에 따라 수정
- tooltip zIndex 추가