### PR TITLE
[HOTFIX] Image 컴포넌트 버그 수정 및 개선, 기타 컨벤션에 따른 수정

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -2,9 +2,7 @@ const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 
 module.exports = {
   stories: ['../src/**/*.stories.@(ts|tsx|mdx)'],
-  addons: [
-    '@storybook/addon-essentials'
-  ],
+  addons: ['@storybook/addon-essentials'],
   framework: '@storybook/react',
   core: {
     builder: '@storybook/builder-webpack5'

--- a/src/components/Alert/index.tsx
+++ b/src/components/Alert/index.tsx
@@ -1,8 +1,8 @@
 import type { HTMLAttributes, PropsWithChildren } from 'react';
 import React, { forwardRef } from 'react';
 
-import { StyledAlert } from './Alert.styles';
 import type { BrandColor, CSSValue, GenericComponentProps } from '../../types';
+import { StyledAlert } from './Alert.styles';
 
 export interface AlertProps extends GenericComponentProps<HTMLAttributes<HTMLDivElement>> {
   round?: CSSValue;

--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -4,8 +4,8 @@ import React, { ReactElement, forwardRef, useEffect, useState } from 'react';
 import Skeleton from '@components/Skeleton';
 import Icon from '@components/Icon';
 
-import { AvatarWrapper, StyledAvatar } from './Avatar.styles';
 import type { CSSValue, GenericComponentProps, IconName } from '../../types';
+import { AvatarWrapper, StyledAvatar } from './Avatar.styles';
 
 export interface AvatarProps extends GenericComponentProps<HTMLAttributes<HTMLDivElement>> {
   src: string;

--- a/src/components/Badge/index.tsx
+++ b/src/components/Badge/index.tsx
@@ -1,8 +1,8 @@
 import React, { forwardRef } from 'react';
 import type { HTMLAttributes } from 'react';
 
-import { StyledBadge, Wrapper } from './Badge.styles';
 import type { BrandColor, CSSValue, GenericComponentProps, Size, Variant } from '../../types';
+import { StyledBadge, Wrapper } from './Badge.styles';
 
 export interface BadgeProps extends GenericComponentProps<HTMLAttributes<HTMLDivElement>> {
   open: boolean;

--- a/src/components/BottomSheet/index.tsx
+++ b/src/components/BottomSheet/index.tsx
@@ -3,8 +3,8 @@ import React, { forwardRef, useEffect, useRef, useState } from 'react';
 
 import { createPortal } from 'react-dom';
 
-import { Content, Rectangle, StyledBottomSheet, SwipeZone, Wrapper } from './BottomSheet.styles';
 import type { CSSValue, GenericComponentProps } from '../../types';
+import { Content, Rectangle, StyledBottomSheet, SwipeZone, Wrapper } from './BottomSheet.styles';
 
 export interface BottomSheetProps extends GenericComponentProps<HTMLAttributes<HTMLDivElement>> {
   open: boolean;

--- a/src/components/Box/index.tsx
+++ b/src/components/Box/index.tsx
@@ -1,8 +1,8 @@
 import type { ElementType, HTMLAttributes, PropsWithChildren } from 'react';
 import React, { forwardRef } from 'react';
 
-import { StyledBox } from './Box.styles';
 import type { GenericComponentProps } from '../../types';
+import { StyledBox } from './Box.styles';
 
 export interface BoxProps extends GenericComponentProps<HTMLAttributes<HTMLDivElement>> {
   component?: ElementType;

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -3,8 +3,8 @@ import React, { forwardRef } from 'react';
 
 import Icon from '@components/Icon';
 
-import { Marker, StyledCheckbox, Wrapper } from './Checkbox.styles';
 import type { BrandColor, GenericComponentProps } from '../../types';
+import { Marker, StyledCheckbox, Wrapper } from './Checkbox.styles';
 
 export interface CheckboxProps
   extends GenericComponentProps<InputHTMLAttributes<HTMLInputElement>> {

--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -3,8 +3,8 @@ import React, { forwardRef, useEffect, useRef, useState } from 'react';
 
 import { createPortal } from 'react-dom';
 
-import { StyledDialog, Wrapper } from './Dialog.styles';
 import type { GenericComponentProps } from '../../types';
+import { StyledDialog, Wrapper } from './Dialog.styles';
 
 export interface DialogProps
   extends GenericComponentProps<Omit<HTMLAttributes<HTMLDivElement>, 'onClick'>> {

--- a/src/components/Fab/index.tsx
+++ b/src/components/Fab/index.tsx
@@ -1,8 +1,8 @@
 import type { ButtonHTMLAttributes } from 'react';
 import React, { forwardRef } from 'react';
 
-import { StyledFab, StyledFabInner } from './Fab.styles';
 import type { GenericComponentProps } from '../../types';
+import { StyledFab, StyledFabInner } from './Fab.styles';
 
 export interface FabProps extends GenericComponentProps<ButtonHTMLAttributes<HTMLButtonElement>> {}
 

--- a/src/components/Flexbox/index.tsx
+++ b/src/components/Flexbox/index.tsx
@@ -1,8 +1,8 @@
 import type { ElementType, HTMLAttributes, PropsWithChildren } from 'react';
 import React, { forwardRef } from 'react';
 
-import { StyledFlexbox } from './Flexbox.styles';
 import type { GenericComponentProps } from '../../types';
+import { StyledFlexbox } from './Flexbox.styles';
 
 export interface FlexboxProps extends GenericComponentProps<HTMLAttributes<HTMLDivElement>> {
   component?: Extract<ElementType, 'div' | 'section' | 'main' | 'article'>;

--- a/src/components/Grid/index.tsx
+++ b/src/components/Grid/index.tsx
@@ -1,8 +1,8 @@
 import type { ElementType, HTMLAttributes, PropsWithChildren } from 'react';
 import React, { forwardRef } from 'react';
 
-import { StyledGrid } from './Grid.styles';
 import type { GenericComponentProps } from '../../types';
+import { StyledGrid } from './Grid.styles';
 
 export interface GridProps extends GenericComponentProps<HTMLAttributes<HTMLDivElement>> {
   component?: Extract<ElementType, 'div' | 'section' | 'main' | 'article'>;

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -1,8 +1,8 @@
 import type { FocusEvent, InputHTMLAttributes, ReactElement } from 'react';
 import React, { forwardRef, useState } from 'react';
 
-import { BaseInput, StyledInput, Unit } from './Input.styles';
 import { CustomStyle, GenericComponentProps, Size, Variant } from '../../types';
+import { BaseInput, StyledInput, Unit } from './Input.styles';
 
 export interface InputProps
   extends GenericComponentProps<Omit<InputHTMLAttributes<HTMLInputElement>, 'size'>> {

--- a/src/components/Label/index.tsx
+++ b/src/components/Label/index.tsx
@@ -1,8 +1,8 @@
 import type { HTMLAttributes, ReactElement } from 'react';
 import React, { forwardRef } from 'react';
 
-import { StyledLabel } from './Label.styles';
 import type { BrandColor, CSSValue, GenericComponentProps, Size, Variant } from '../../types';
+import { StyledLabel } from './Label.styles';
 
 export interface LabelProps extends GenericComponentProps<HTMLAttributes<HTMLLabelElement>> {
   variant?: Exclude<Variant, 'inline'> | 'darked';

--- a/src/components/Radio/index.tsx
+++ b/src/components/Radio/index.tsx
@@ -3,8 +3,8 @@ import React, { forwardRef } from 'react';
 
 import Icon from '@components/Icon';
 
-import { Marker, StyledRadio, Wrapper } from './Radio.styles';
 import type { BrandColor, GenericComponentProps } from '../../types';
+import { Marker, StyledRadio, Wrapper } from './Radio.styles';
 
 export interface RadioProps extends GenericComponentProps<InputHTMLAttributes<HTMLInputElement>> {
   brandColor?: Extract<BrandColor, 'primary' | 'black'>;

--- a/src/components/Rating/index.tsx
+++ b/src/components/Rating/index.tsx
@@ -5,8 +5,8 @@ import Icon from '@components/Icon';
 
 import { useTheme } from '@theme';
 
-import { StyledRating } from './Rating.styles';
 import type { GenericComponentProps, Size } from '../../types';
+import { StyledRating } from './Rating.styles';
 
 export interface RatingProps extends GenericComponentProps<HTMLAttributes<HTMLDivElement>> {
   count: number;

--- a/src/components/Skeleton/index.tsx
+++ b/src/components/Skeleton/index.tsx
@@ -1,8 +1,8 @@
 import React, { forwardRef } from 'react';
 import type { HTMLAttributes } from 'react';
 
-import { SkeletonInner, SkeletonWrapper, StyledSkeleton } from './Skeleton.styles';
 import type { CSSValue, GenericComponentProps } from '../../types';
+import { SkeletonInner, SkeletonWrapper, StyledSkeleton } from './Skeleton.styles';
 
 export interface SkeletonProps extends GenericComponentProps<HTMLAttributes<HTMLDivElement>> {
   ratio?: '1:1' | '1:2' | '2:1' | '4:3' | '5:6' | '16:9';

--- a/src/components/Stepper/index.tsx
+++ b/src/components/Stepper/index.tsx
@@ -1,8 +1,8 @@
 import type { HTMLAttributes } from 'react';
 import React, { forwardRef } from 'react';
 
-import { StepperItem, StyledStepper } from './Stepper.styles';
 import type { GenericComponentProps } from '../../types';
+import { StepperItem, StyledStepper } from './Stepper.styles';
 
 export interface StepperProps extends GenericComponentProps<HTMLAttributes<HTMLDivElement>> {
   count: number;

--- a/src/components/Switch/index.tsx
+++ b/src/components/Switch/index.tsx
@@ -1,8 +1,8 @@
 import type { ButtonHTMLAttributes, MouseEvent } from 'react';
 import React, { forwardRef } from 'react';
 
-import { Circle, StyledSwitch } from './Switch.styles';
 import type { GenericComponentProps, Size } from '../../types';
+import { Circle, StyledSwitch } from './Switch.styles';
 
 export interface SwitchProps
   extends GenericComponentProps<

--- a/src/components/Tab/index.tsx
+++ b/src/components/Tab/index.tsx
@@ -1,8 +1,8 @@
 import React, { forwardRef } from 'react';
 import type { ButtonHTMLAttributes, ReactElement } from 'react';
 
-import { StyledTab } from './Tab.styles';
 import type { BrandColor, GenericComponentProps, Size } from '../../types';
+import { StyledTab } from './Tab.styles';
 
 export interface TabProps extends GenericComponentProps<ButtonHTMLAttributes<HTMLButtonElement>> {
   brandColor?: Extract<BrandColor, 'primary' | 'black'>;

--- a/src/components/TabGroup/index.tsx
+++ b/src/components/TabGroup/index.tsx
@@ -1,8 +1,8 @@
 import type { HTMLAttributes, MouseEvent } from 'react';
 import React, { forwardRef, useEffect, useRef } from 'react';
 
-import { StyledTabGroup, TabGroupInner } from './TabGroup.styles';
 import type { BrandColor, GenericComponentProps, Size } from '../../types';
+import { StyledTabGroup, TabGroupInner } from './TabGroup.styles';
 
 export interface TabGroupProps
   extends GenericComponentProps<Omit<HTMLAttributes<HTMLDivElement>, 'onClick' | 'onChange'>> {

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -4,8 +4,8 @@ import React, { forwardRef, useContext, useEffect, useRef, useState } from 'reac
 import { createPortal } from 'react-dom';
 import PortalCounterContext from '@theme/provider/PortalCounterContext';
 
-import { StyledToast } from './Toast.styles';
 import type { CSSValue, GenericComponentProps } from '../../types';
+import { StyledToast } from './Toast.styles';
 
 export interface ToastProps
   extends GenericComponentProps<Omit<HTMLAttributes<HTMLDivElement>, 'onClick'>> {

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -1,8 +1,8 @@
 import type { HTMLAttributes, PropsWithChildren, ReactElement } from 'react';
 import React, { forwardRef, useEffect, useRef, useState } from 'react';
 
-import { StyledTooltip, Wrapper } from './Tooltip.styles';
 import type { BrandColor, GenericComponentProps, Variant } from '../../types';
+import { StyledTooltip, Wrapper } from './Tooltip.styles';
 
 export interface TooltipProps extends GenericComponentProps<HTMLAttributes<HTMLDivElement>> {
   variant?: Extract<Variant, 'solid' | 'ghost'>;

--- a/src/theme/provider/useTheme.ts
+++ b/src/theme/provider/useTheme.ts
@@ -1,8 +1,8 @@
 import { useContext, useMemo } from 'react';
 
-import ThemeContext from './ThemeContext';
 import light from '../light';
 import dark from '../dark';
+import ThemeContext from './ThemeContext';
 
 function useTheme() {
   const themeContext = useContext(ThemeContext);


### PR DESCRIPTION
- props 로 전달한 onLoad, onError 이벤트가 트리거 될 수 있도록 수정
- disableFallback props 추가
- disableOnBackground 활성화에 따른 내부 onLoad, onError 이벤트 트리거 분리 적용
- disableOnBackground 활성화 여부에 따라 이미지가 렌더링 되지 않던 케이스 수정